### PR TITLE
fixing issue #2

### DIFF
--- a/shibby.sh
+++ b/shibby.sh
@@ -318,6 +318,12 @@ searchForBook() {
       fi
     done
     x=$(( $x + 1 ))
+      if [[ $availableLocations == "" ]]; then
+        availableLocations="<<unavailable>>"
+      fi
+      if [[ $holdableLocations == "" ]]; then
+        holdableLocations="<<check it out instead!>>"
+      fi
     allResults="${allResults}""${bookInfo}"_"${availableLocations}"_"${holdableLocations}""${formatCharacters}"
   done
   rm -rf $TMP_DIR


### PR DESCRIPTION
The problem was that if no locations had the book available, then that value within the table was `""`, and the `column` command must read that as being nothing and just ignored it and shifted all data to the right of it (the `Holdable column`) left. 

The fix was to add a default value if it is ever empty. 